### PR TITLE
fix error. masonite>=4.0<5.0

### DIFF
--- a/masonite-{{cookiecutter.project_slug}}/setup.py
+++ b/masonite-{{cookiecutter.project_slug}}/setup.py
@@ -63,7 +63,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["masonite>=4.0<5.0"],
+    install_requires=["masonite>=4.0,<5.0"],
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example:


### PR DESCRIPTION
Error:

```
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in masonite-lang setup command: 'install_requires' must be a string or iterable of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          masonite>=4.0<5.0
                  ~~~~~^
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
make: *** [init] Error 1
```